### PR TITLE
Update mesos package version on Ubuntu Trusty

### DIFF
--- a/vars/versions.yml
+++ b/vars/versions.yml
@@ -7,7 +7,7 @@ docker_package_version: "0"
 docker_registry_version: "2.3.1"
 
 mesos_version: "1.0.1"
-mesos_package_version: "{% if ansible_distribution_release == 'xenial' %}2.0.94{% else %}2.0.89{% endif %}"
+mesos_package_version: "{% if ansible_distribution_release == 'xenial' %}2.0.94{% else %}2.0.93{% endif %}"
 mesos_ui_version: "standalone-0.1.4"
 marathon_version: "1.3.0"
 marathon_package_version: "1.0.506"


### PR DESCRIPTION
Seems the mesos package version has been updated on 14.04.5 LTSTrusty.
